### PR TITLE
Sugestão de melhoria de texto no tópico Rebasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Ainda lembramos que uma branch é sempre baseada em outra. Quando você a cria, 
 
 No nosso exemplo de mesclagem simples, ramificamos a _master_ em um commit específico e, em seguida, fizemos commit de algumas mudanças no _master_ e na branch `change_alice`.
 
-Quando uma ramificação está divergindo daquela em que se baseia e você deseja integrar as alterações mais recentes em sua ramificação atual, o `rebase` oferece uma maneira mais limpa de fazer isso do que uma `mesclagem` faria.
+Quando uma ramificação está divergindo daquela em que se baseia e você deseja integrar as alterações mais recentes em sua ramificação atual, o `rebase` oferece uma maneira mais limpa de fazer isso do que uma mesclagem (`merge`) faria.
 
 Como vimos, um `merge` introduz um _merge commit_ no qual os dois históricos são integrados novamente.
 


### PR DESCRIPTION
Olá :D
Estava fazendo esse curso e achei que a sugestão sugerida nesse PR faz sentido, já que em outros momentos no texto do seu curso você use o padrão: [nome em português] (nome em inglês)
Exemplo: 

> [...] você pode simplesmente cancelar (`abort`) executando o comando `git merge --abort`.

É só uma sugestão mesmo, se achar que não faz sentido, pode cancelar o PR sem problemas :D (óbvio né, o projeto é seu KKKK)